### PR TITLE
Add PR auto-label + triage comment workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,33 @@
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "public/**"
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "server/**"
+          - "api/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "test/**"
+          - "tests/**"
+          - "**/*.spec.js"
+          - "**/*.test.js"
+
+devops:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "Dockerfile"
+          - "docker-compose.yml"
+          - "render.yaml"
+          - "vercel.json"

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,18 @@
+name: PR Auto Label
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from changed files
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-triage-comment.yml
+++ b/.github/workflows/pr-triage-comment.yml
@@ -1,0 +1,36 @@
+name: PR Triage Comment
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  triage-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post contributor guidance comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const body = [
+              `Thanks @${author} for the PR.`,
+              ``,
+              `Quick checklist to speed up review:`,
+              `- Fill in the PR template sections fully`,
+              `- Add test notes (what you ran + expected output)`,
+              `- Keep scope limited to one issue/topic`,
+              `- Include screenshots for UI changes`,
+              ``,
+              `Maintainers will review and either request changes or merge.`
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });


### PR DESCRIPTION
Adds:\n- file-based PR auto-labeling via .github/labeler.yml\n- automatic triage guidance comment on new PRs\n\nAlso created matching labels in the repository settings (frontend, backend, tests, devops).